### PR TITLE
UDP Communication

### DIFF
--- a/etherShield.cpp
+++ b/etherShield.cpp
@@ -49,6 +49,10 @@ void EtherShield::ES_make_arp_answer_from_request(uint8_t *buf){
 	make_arp_answer_from_request(buf);
 }
 
+void EtherShield::ES_make_udp_reply_from_request(uint8_t *buf,uint8_t *data,uint8_t datalen,uint16_t port){
+	make_udp_reply_from_request(buf, data, datalen, port);
+}
+
 uint8_t EtherShield::ES_eth_type_is_ip_and_my_ip(uint8_t *buf,uint16_t len){
 	return eth_type_is_ip_and_my_ip(buf, len);
 }

--- a/etherShield.h
+++ b/etherShield.h
@@ -40,6 +40,7 @@ class EtherShield
 		void ES_init_ip_arp_udp_tcp(uint8_t *mymac,uint8_t *myip,uint8_t wwwp);
 		uint8_t ES_eth_type_is_arp_and_my_ip(uint8_t *buf,uint16_t len);
 		void ES_make_arp_answer_from_request(uint8_t *buf);
+		void ES_make_udp_reply_from_request(uint8_t *buf,uint8_t *data,uint8_t datalen,uint16_t port);
 		uint8_t ES_eth_type_is_ip_and_my_ip(uint8_t *buf,uint16_t len);
 		void ES_make_echo_reply_from_request(uint8_t *buf,uint16_t len);
 		void ES_make_tcp_synack_from_syn(uint8_t *buf);

--- a/ip_arp_udp_tcp.c
+++ b/ip_arp_udp_tcp.c
@@ -363,7 +363,7 @@ void make_echo_reply_from_request(uint8_t *buf,uint16_t len)
 }
 
 // you can send a max of 220 bytes of data
-void make_udp_reply_from_request(uint8_t *buf,char *data,uint8_t datalen,uint16_t port)
+void make_udp_reply_from_request(uint8_t *buf,uint8_t *data,uint8_t datalen,uint16_t port)
 {
         uint8_t i=0;
         uint16_t ck;

--- a/ip_arp_udp_tcp.h
+++ b/ip_arp_udp_tcp.h
@@ -23,7 +23,7 @@ extern uint8_t eth_type_is_arp_and_my_ip(uint8_t *buf,uint16_t len);
 extern uint8_t eth_type_is_ip_and_my_ip(uint8_t *buf,uint16_t len);
 extern void make_arp_answer_from_request(uint8_t *buf);
 extern void make_echo_reply_from_request(uint8_t *buf,uint16_t len);
-extern void make_udp_reply_from_request(uint8_t *buf,char *data,uint8_t datalen,uint16_t port);
+extern void make_udp_reply_from_request(uint8_t *buf,uint8_t *data,uint8_t datalen,uint16_t port);
 
 
 extern void make_tcp_synack_from_syn(uint8_t *buf);


### PR DESCRIPTION
On lightweight devices UDP communication can come in handy as a lightweight form of communication. These patches expose the functionality of the underlying libraries through the EtherShield object.

I changed the type from char\* to uint8_t\* to better reflect the underlying types used.
